### PR TITLE
Use ConcurrentHashMap and update lib version to reuse code

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("com.amazon.redshift:redshift-jdbc4-no-awssdk:1.2.45.1069")
-  implementation("uk.gov.justice.service.hmpps:hmpps-digital-prison-reporting-lib:1.1.2")
+  implementation("uk.gov.justice.service.hmpps:hmpps-digital-prison-reporting-lib:1.1.4")
 
   // Security
   implementation("org.springframework.boot:spring-boot-starter-security")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/InMemoryProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/InMemoryProductDefinitionRepository.kt
@@ -2,18 +2,14 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportingtoolsapi.data
 
 import jakarta.validation.ValidationException
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ProductDefinitionRepository
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.AbstractProductDefinitionRepository
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ProductDefinition
-import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SingleReportProductDefinition
+import java.util.concurrent.ConcurrentHashMap
 
 @Service
-class InMemoryProductDefinitionRepository : ProductDefinitionRepository {
+class InMemoryProductDefinitionRepository : AbstractProductDefinitionRepository() {
 
-  companion object {
-    private const val schemaRefPrefix = "\$ref:"
-  }
-
-  private val definitions: MutableMap<String, ProductDefinition> = HashMap()
+  private val definitions: ConcurrentHashMap<String, ProductDefinition> = ConcurrentHashMap()
 
   override fun getProductDefinitions(): List<ProductDefinition> {
     return definitions.values.toList()
@@ -21,30 +17,6 @@ class InMemoryProductDefinitionRepository : ProductDefinitionRepository {
 
   override fun getProductDefinition(definitionId: String): ProductDefinition =
     definitions.getOrElse(definitionId) { throw ValidationException("Invalid report id provided: $definitionId") }
-
-  override fun getSingleReportProductDefinition(definitionId: String, reportId: String): SingleReportProductDefinition {
-    val productDefinition = getProductDefinition(definitionId)
-    val reportDefinition = productDefinition.report
-      .filter { it.id == reportId }
-      .ifEmpty { throw ValidationException("Invalid report variant id provided: $reportId") }
-      .first()
-
-    val dataSetId = reportDefinition.dataset.removePrefix(schemaRefPrefix)
-    val dataSet = productDefinition.dataset
-      .filter { it.id == dataSetId }
-      .ifEmpty { throw ValidationException("Invalid dataSetId in report: $dataSetId") }
-      .first()
-
-    return SingleReportProductDefinition(
-      id = definitionId,
-      name = productDefinition.name,
-      description = productDefinition.description,
-      metadata = productDefinition.metadata,
-      datasource = productDefinition.datasource.first(),
-      dataset = dataSet,
-      report = reportDefinition,
-    )
-  }
 
   fun save(definition: ProductDefinition) {
     definitions[definition.id] = definition

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/integration/security/FakeCaseloadProvider.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/integration/security/FakeCaseloadProvider.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportingtoolsapi.integration.security
+
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.CaseloadProvider
+
+@Component
+class FakeCaseloadProvider : CaseloadProvider {
+  override fun getActiveCaseloadIds(jwt: Jwt): List<String> {
+    return listOf("LWSTMC")
+  }
+}


### PR DESCRIPTION
This PR includes two main changes:
- Use of ConcurrentHashMap instead of Mutable map for thread safe retrieval and modification of the map.
- Updated the lib version and removed getSingleReportProductDefinition implementation from tools-api as it is now in the library and is reused.
- Added FakeCaseloadProvider as the new version of the library makes calls to the caseloads endpoint to get the definitions.