### PR TITLE
DPR2-341 bumped version to include formula interpolation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("com.amazon.redshift:redshift-jdbc4-no-awssdk:1.2.45.1069")
-  implementation("uk.gov.justice.service.hmpps:hmpps-digital-prison-reporting-lib:3.0.1")
+  implementation("uk.gov.justice.service.hmpps:hmpps-digital-prison-reporting-lib:3.0.3")
   implementation("com.google.code.gson:gson:2.10.1")
 
   // Security

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/integration/ReportDefinitionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/integration/ReportDefinitionIntegrationTest.kt
@@ -65,7 +65,7 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
             "template": "list",
             "field": [
               {
-                "name": "F30",
+                "name": "${'$'}ref:F30",
                 "display": "51",
                 "wordWrap": "None",
                 "filter": {
@@ -77,7 +77,6 @@ class ReportDefinitionIntegrationTest : IntegrationTestBase() {
                 },
                 "sortable": true,
                 "defaultsort": false,
-                "formula": "52",
                 "visible": true
               }
             ]


### PR DESCRIPTION
This PR includes a change to one of the integration tests as now that the formula is taking effect, it is overwriting the field value with "52".
So I have removed the formula.
Note: The intention of this test is to test the proper deserialisation of the GSON annotated properties. 
However, this does not seem to work as intended and it is also not being caught by the test.
The "dynamicOptions" key is returned in camel case instead of all lower case as specified in the  `@SerializedName("dynamicoptions")` annotation.