### PR TITLE
DPR2-1251 update lib

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -10,3 +10,6 @@
 # Suppression for h2 2.1.214 password on command line vulnerability
 #   can be suppressed as we only run h2 locally and not on build environments
 CVE-2022-45868
+# Suppression for tomcat vulnerability affecting jsp compilation in the default servlet
+#   can be suppressed as we do not use the default servlet and haven't configured it for write either
+CVE-2024-50379

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("com.amazon.redshift:redshift-jdbc4-no-awssdk:1.2.45.1069")
   implementation("org.postgresql:postgresql:42.7.4")
-  implementation("uk.gov.justice.service.hmpps:hmpps-digital-prison-reporting-lib:7.3.14")
+  implementation("uk.gov.justice.service.hmpps:hmpps-digital-prison-reporting-lib:7.3.15")
   implementation("com.google.code.gson:gson:2.11.0")
   implementation("software.amazon.awssdk:redshiftdata:2.29.46")
   implementation("software.amazon.awssdk:athena:2.29.20")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "6.0.8"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "6.1.2"
   kotlin("jvm") version "2.0.21"
   kotlin("plugin.spring") version "2.0.21"
   id("jacoco")
@@ -27,7 +27,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
 
   // Swagger
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.1")
 
   // Testing
   testImplementation("com.h2database:h2")


### PR DESCRIPTION
As part of the BE library update I updated also some other dependencies as some BE library dependency version bumps from Dependabot which are part of version 7.3.15 were causing the below error:
```
...
Caused by: java.lang.IllegalStateException: Error processing condition on org.springdoc.webmvc.ui.SwaggerConfig.springWebProvider

  Caused by: java.lang.IllegalStateException: Failed to introspect Class [org.springdoc.webmvc.ui.SwaggerConfig] from ClassLoader [jdk.internal.loader.ClassLoaders$AppClassLoader@76ed5528]

  Caused by: java.lang.NoClassDefFoundError: org/springdoc/ui/AbstractSwaggerResourceResolver

  Caused by: java.lang.ClassNotFoundException: org.springdoc.ui.AbstractSwaggerResourceResolver
```