### PR TITLE
Dpr2 1816 Configurable Redshift As the Definitions storage 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,10 +118,10 @@ workflows:
           name: helm_lint
       - build_multiplatform_docker_job:
           name: build_docker
-#          filters:
-#            branches:
-#              only:
-#                - main
+          filters:
+            branches:
+              only:
+                - main
           requires:
             - helm_lint
             - validate
@@ -133,10 +133,10 @@ workflows:
           context:
             - hmpps-common-vars
             - hmpps-dpr-tools-api-dev
-#          filters:
-#            branches:
-#              only:
-#                - main
+          filters:
+            branches:
+              only:
+                - main
           requires:
             - validate
             - build_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,10 +118,10 @@ workflows:
           name: helm_lint
       - build_multiplatform_docker_job:
           name: build_docker
-          filters:
-            branches:
-              only:
-                - main
+#          filters:
+#            branches:
+#              only:
+#                - main
           requires:
             - helm_lint
             - validate
@@ -133,10 +133,10 @@ workflows:
           context:
             - hmpps-common-vars
             - hmpps-dpr-tools-api-dev
-          filters:
-            branches:
-              only:
-                - main
+#          filters:
+#            branches:
+#              only:
+#                - main
           requires:
             - validate
             - build_docker

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/CrudProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/CrudProductDefinitionRepository.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportingtoolsapi.data
+
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.ProductDefinitionRepository
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ProductDefinition
+
+interface CrudProductDefinitionRepository : ProductDefinitionRepository {
+
+  fun save(definition: ProductDefinition, originalBody: String)
+
+  fun deleteById(definitionId: String)
+
+  fun getOriginalBody(definitionId: String): String?
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/InMemoryProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/InMemoryProductDefinitionRepository.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.digitalprisonreportingtoolsapi.data
 
 import jakarta.validation.ValidationException
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.AbstractProductDefinitionRepository
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.IdentifiedHelper
@@ -9,8 +10,11 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SingleR
 import uk.gov.justice.digital.hmpps.digitalprisonreportingtoolsapi.exception.DefinitionNotFoundException
 import java.util.concurrent.ConcurrentHashMap
 
+@ConditionalOnMissingBean(RedshiftProductDefinitionRepository::class)
 @Service
-class InMemoryProductDefinitionRepository(identifiedHelper: IdentifiedHelper) : AbstractProductDefinitionRepository(identifiedHelper) {
+class InMemoryProductDefinitionRepository(identifiedHelper: IdentifiedHelper) :
+  AbstractProductDefinitionRepository(identifiedHelper),
+  CrudProductDefinitionRepository {
 
   private val definitions: ConcurrentHashMap<String, Pair<ProductDefinition, String>> = ConcurrentHashMap()
 
@@ -26,13 +30,13 @@ class InMemoryProductDefinitionRepository(identifiedHelper: IdentifiedHelper) : 
     }
   }
 
-  fun save(definition: ProductDefinition, originalBody: String) {
+  override fun save(definition: ProductDefinition, originalBody: String) {
     definitions[definition.id] = Pair(definition, originalBody)
   }
 
-  fun deleteById(definitionId: String) {
+  override fun deleteById(definitionId: String) {
     definitions.remove(definitionId)
   }
 
-  fun getOriginalBody(definitionId: String) = definitions[definitionId]?.second
+  override fun getOriginalBody(definitionId: String) = definitions[definitionId]?.second
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/InMemoryProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/InMemoryProductDefinitionRepository.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.digitalprisonreportingtoolsapi.data
 
 import jakarta.validation.ValidationException
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Primary
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.AbstractProductDefinitionRepository
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.IdentifiedHelper
@@ -12,6 +13,7 @@ import java.util.concurrent.ConcurrentHashMap
 
 @ConditionalOnMissingBean(RedshiftProductDefinitionRepository::class)
 @Service
+@Primary
 class InMemoryProductDefinitionRepository(identifiedHelper: IdentifiedHelper) :
   AbstractProductDefinitionRepository(identifiedHelper),
   CrudProductDefinitionRepository {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/RedshiftProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/RedshiftProductDefinitionRepository.kt
@@ -90,7 +90,7 @@ class RedshiftProductDefinitionRepository(
     val stopwatch = StopWatch.createStarted()
     val sql = """
         MERGE INTO $database.$schema.$table
-        USING (SELECT cast(? as VARCHAR(max)) as ID, cast(? as VARCHAR(max)) as DEFINITION) as source
+        USING (SELECT cast(? as VARCHAR(max)) as ID, cast(? as VARCHAR(65535)) as DEFINITION) as source
         on $database.$schema.$table.ID = source.ID 
         WHEN MATCHED THEN
         UPDATE SET ID = source.ID, DEFINITION = source.DEFINITION

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/RedshiftProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/RedshiftProductDefinitionRepository.kt
@@ -93,6 +93,7 @@ class RedshiftProductDefinitionRepository(
     val delete = "DELETE FROM $database.$schema.$table WHERE ID=?;"
     log.debug("SQL query: $delete")
     jdbcTemplate.update(delete, definition.id)
+    throw RuntimeException("Failed to save definition.")
     val insert = "INSERT INTO $database.$schema.$table (id, definition) VALUES (?,?);"
     log.debug("SQL query: $insert")
     jdbcTemplate.update(insert, definition.id, originalBody)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/RedshiftProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/RedshiftProductDefinitionRepository.kt
@@ -98,7 +98,7 @@ class RedshiftProductDefinitionRepository(
         THEN INSERT VALUES (source.ID, source.DEFINITION)
     """.trimIndent()
     log.debug("SQL query: $sql")
-    jdbcTemplate.update(sql, "'$definition.id'", originalBody)
+    jdbcTemplate.update(sql, "'${definition.id}'", originalBody)
     stopwatch.stop()
     log.debug("Saved definition into Redshift in {} ms.", stopwatch.time)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/RedshiftProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/RedshiftProductDefinitionRepository.kt
@@ -98,7 +98,7 @@ class RedshiftProductDefinitionRepository(
         THEN INSERT VALUES (source.ID, source.DEFINITION)
     """.trimIndent()
     log.debug("SQL query: $sql")
-    jdbcTemplate.update(sql, "'$definition.id'", "'$originalBody'")
+    jdbcTemplate.update(sql, "'$definition.id'", originalBody)
     stopwatch.stop()
     log.debug("Saved definition into Redshift in {} ms.", stopwatch.time)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/RedshiftProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/RedshiftProductDefinitionRepository.kt
@@ -90,7 +90,7 @@ class RedshiftProductDefinitionRepository(
     val stopwatch = StopWatch.createStarted()
     val sql = """
         MERGE INTO $database.$schema.$table
-        USING (SELECT '?' as ID, '?' as DEFINITION) as source
+        USING (SELECT ? as ID, ? as DEFINITION) as source
         on $database.$schema.$table.ID = source.ID 
         WHEN MATCHED THEN
         UPDATE SET ID = source.ID, DEFINITION = source.DEFINITION

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/RedshiftProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/RedshiftProductDefinitionRepository.kt
@@ -90,7 +90,7 @@ class RedshiftProductDefinitionRepository(
     val stopwatch = StopWatch.createStarted()
     val sql = """
         MERGE INTO $database.$schema.$table
-        USING (SELECT ?::VARCHAR as ID, ? as DEFINITION::VARCHAR) as source
+        USING (SELECT cast(? as VARCHAR(max)) as ID, cast(? as VARCHAR(max)) as DEFINITION) as source
         on $database.$schema.$table.ID = source.ID 
         WHEN MATCHED THEN
         UPDATE SET ID = source.ID, DEFINITION = source.DEFINITION

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/RedshiftProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/RedshiftProductDefinitionRepository.kt
@@ -90,7 +90,7 @@ class RedshiftProductDefinitionRepository(
     val stopwatch = StopWatch.createStarted()
     val sql = """
         MERGE INTO $database.$schema.$table
-        USING (SELECT cast(? as VARCHAR(max)) as ID, cast(? as VARCHAR(65535)) as DEFINITION) as source
+        USING (SELECT cast(? as VARCHAR(max)) as ID, cast(? as SUPER) as DEFINITION) as source
         on $database.$schema.$table.ID = source.ID 
         WHEN MATCHED THEN
         UPDATE SET ID = source.ID, DEFINITION = source.DEFINITION

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/RedshiftProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/RedshiftProductDefinitionRepository.kt
@@ -90,7 +90,7 @@ class RedshiftProductDefinitionRepository(
     val stopwatch = StopWatch.createStarted()
     val sql = """
         MERGE INTO $database.$schema.$table
-        USING (SELECT ? as ID, ? as DEFINITION) as source
+        USING (SELECT ?::VARCHAR as ID, ? as DEFINITION::VARCHAR) as source
         on $database.$schema.$table.ID = source.ID 
         WHEN MATCHED THEN
         UPDATE SET ID = source.ID, DEFINITION = source.DEFINITION

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/RedshiftProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/RedshiftProductDefinitionRepository.kt
@@ -1,0 +1,154 @@
+package uk.gov.justice.digital.hmpps.digitalprisonreportingtoolsapi.data
+
+import com.google.gson.Gson
+import jakarta.validation.ValidationException
+import org.apache.commons.lang3.time.StopWatch
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.dao.EmptyResultDataAccessException
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.AbstractProductDefinitionRepository
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.IdentifiedHelper
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.ProductDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.data.model.SingleReportProductDefinition
+import uk.gov.justice.digital.hmpps.digitalprisonreportingtoolsapi.config.RedshiftDataSourceConfiguration
+import uk.gov.justice.digital.hmpps.digitalprisonreportingtoolsapi.exception.DefinitionNotFoundException
+import javax.sql.DataSource
+
+@ConditionalOnProperty("dpr.lib.definition.redshift.enabled", havingValue = "true")
+@ConditionalOnBean(RedshiftDataSourceConfiguration::class)
+@Service
+class RedshiftProductDefinitionRepository(
+  identifiedHelper: IdentifiedHelper,
+  val dprDefinitionGson: Gson,
+  @Value("\${dpr.lib.definition.redshift.database:datamart}") private val database: String,
+  @Value("\${dpr.lib.definition.redshift.schema:product}") private val schema: String,
+  @Value("\${dpr.lib.definition.redshift.table:data_product }") private val table: String,
+) : AbstractProductDefinitionRepository(identifiedHelper),
+  CrudProductDefinitionRepository {
+
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  @Autowired
+  @Qualifier("redshift")
+  lateinit var dataSource: DataSource
+
+  override fun getProductDefinitions(path: String?): List<ProductDefinition> {
+    log.debug("Fetching definitions from Redshift.")
+    val stopwatch = StopWatch.createStarted()
+    val jdbcTemplate = JdbcTemplate(dataSource)
+    val definitions: List<ProductDefinition> = jdbcTemplate.queryForList(
+      "SELECT DEFINITION FROM $database.$schema.$table;",
+    ).map {
+      it.entries.associate { (k, v) -> k to dprDefinitionGson.fromJson(v as String, ProductDefinition::class.java) }
+    }.flatMap { it.values }
+    stopwatch.stop()
+    log.debug("Retrieved definitions from Redshift in {} ms.", stopwatch.time)
+    return definitions
+  }
+
+  override fun getProductDefinition(definitionId: String, dataProductDefinitionsPath: String?): ProductDefinition {
+    try {
+      val stopwatch = StopWatch.createStarted()
+      val jdbcTemplate = JdbcTemplate(dataSource)
+      val sql = "SELECT DEFINITION FROM $database.$schema.$table WHERE ID=?"
+      log.debug("Retrieving definition with id $definitionId from Redshift.")
+      log.debug("SQL query: $sql")
+      val definition = jdbcTemplate.queryForObject(
+        sql,
+        { rs, _ ->
+          dprDefinitionGson.fromJson(rs.getString("definition"), ProductDefinition::class.java)
+        },
+        definitionId,
+      )
+      log.debug("Retrieved definition with id: $definitionId from Redshift in {} ms.", stopwatch.time)
+      return definition
+    } catch (e: EmptyResultDataAccessException) {
+      throw DefinitionNotFoundException("Invalid report id provided: $definitionId")
+    }
+  }
+
+  override fun getSingleReportProductDefinition(definitionId: String, reportId: String, dataProductDefinitionsPath: String?): SingleReportProductDefinition {
+    try {
+      return super.getSingleReportProductDefinition(definitionId, reportId, null)
+    } catch (e: ValidationException) {
+      throw DefinitionNotFoundException(e.message)
+    }
+  }
+
+  override fun save(definition: ProductDefinition, originalBody: String) {
+    log.debug("Saving definition with id ${definition.id} into Redshift.")
+    val stopwatch = StopWatch.createStarted()
+    val jdbcTemplate = NamedParameterJdbcTemplate(dataSource)
+    val sql = """
+      MERGE INTO $database.$schema.$table as target 
+      USING (VALUES (:id, :definition, :originalBody)) 
+      AS source (id, definition, original_body)
+      ON target.id = source.id
+      WHEN MATCHED THEN
+      UPDATE SET 
+      target.definition = source.definition,
+      target.original_body = source.original_body
+      WHEN NOT MATCHED THEN
+      INSERT (id, definition, original_body)
+      VALUES (source.id, source.definition, source.originalBody)
+    """.trimIndent()
+    val namedParamsMap = MapSqlParameterSource()
+    namedParamsMap.addValue("id", definition.id)
+    namedParamsMap.addValue("definition", definition)
+    namedParamsMap.addValue("originalBody", originalBody)
+    log.debug("SQL query: $sql")
+    jdbcTemplate.update(
+      sql,
+      namedParamsMap,
+    )
+    stopwatch.stop()
+    log.debug("Saved definition into Redshift in {} ms.", stopwatch.time)
+  }
+
+  override fun deleteById(definitionId: String) {
+    log.debug("Deleting definition with id $definitionId from Redshift.")
+    val stopwatch = StopWatch.createStarted()
+    val jdbcTemplate = NamedParameterJdbcTemplate(dataSource)
+    val sql = "DELETE FROM $database.$schema.$table WHERE ID=?"
+    val namedParamsMap = MapSqlParameterSource()
+    namedParamsMap.addValue("id", definitionId)
+    log.debug("SQL query: $sql")
+    val deletedRows = jdbcTemplate.update(
+      sql,
+      namedParamsMap,
+    )
+    stopwatch.stop()
+    log.debug("Deleted $deletedRows rows with definition with ID: $definitionId from Redshift in {}.", stopwatch.time)
+  }
+
+  override fun getOriginalBody(definitionId: String): String? {
+    try {
+      val stopwatch = StopWatch.createStarted()
+      val jdbcTemplate = JdbcTemplate(dataSource)
+      val sql = "SELECT ORIGINAL_BODY FROM $database.$schema.$table WHERE ID=?"
+      log.debug("Retrieving original_body with id $definitionId from Redshift.")
+      log.debug("SQL query: $sql")
+      val originalBody = jdbcTemplate.queryForObject(
+        sql,
+        { rs, _ ->
+          rs.getString("original_body")
+        },
+        definitionId,
+      )
+      log.debug("Retrieved original_body with definition id: $definitionId from Redshift in {} ms.", stopwatch.time)
+      return originalBody
+    } catch (e: EmptyResultDataAccessException) {
+      throw DefinitionNotFoundException("Invalid report id provided: $definitionId")
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/RedshiftProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/RedshiftProductDefinitionRepository.kt
@@ -98,7 +98,7 @@ class RedshiftProductDefinitionRepository(
         THEN INSERT VALUES (source.ID, source.DEFINITION)
     """.trimIndent()
     log.debug("SQL query: $sql")
-    jdbcTemplate.update(sql, definition.id, originalBody)
+    jdbcTemplate.update(sql, "'$definition.id'", "'$originalBody'")
     stopwatch.stop()
     log.debug("Saved definition into Redshift in {} ms.", stopwatch.time)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/RedshiftProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/RedshiftProductDefinitionRepository.kt
@@ -98,7 +98,7 @@ class RedshiftProductDefinitionRepository(
         THEN INSERT VALUES (source.ID, source.DEFINITION)
     """.trimIndent()
     log.debug("SQL query: $sql")
-    jdbcTemplate.update(sql, "'${definition.id}'", originalBody)
+    jdbcTemplate.update(sql, definition.id, originalBody)
     stopwatch.stop()
     log.debug("Saved definition into Redshift in {} ms.", stopwatch.time)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/RedshiftProductDefinitionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/data/RedshiftProductDefinitionRepository.kt
@@ -90,7 +90,7 @@ class RedshiftProductDefinitionRepository(
     val stopwatch = StopWatch.createStarted()
     val sql = """
         MERGE INTO $database.$schema.$table
-        USING (SELECT cast(? as VARCHAR(max)) as ID, cast(? as SUPER) as DEFINITION) as source
+        USING (SELECT cast(? as VARCHAR(max)) as ID, json_parse(?) as DEFINITION) as source
         on $database.$schema.$table.ID = source.ID 
         WHEN MATCHED THEN
         UPDATE SET ID = source.ID, DEFINITION = source.DEFINITION

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/service/DefinitionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/digitalprisonreportingtoolsapi/service/DefinitionService.kt
@@ -8,12 +8,12 @@ import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.security.DprAuthAw
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.ProductDefinitionTokenPolicyChecker
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.ReportDefinitionMapper
 import uk.gov.justice.digital.hmpps.digitalprisonreportinglib.service.estcodesandwings.EstablishmentCodesToWingsCacheService
-import uk.gov.justice.digital.hmpps.digitalprisonreportingtoolsapi.data.InMemoryProductDefinitionRepository
+import uk.gov.justice.digital.hmpps.digitalprisonreportingtoolsapi.data.CrudProductDefinitionRepository
 import uk.gov.justice.digital.hmpps.digitalprisonreportingtoolsapi.exception.InvalidDefinitionException
 
 @Service
 class DefinitionService(
-  private val repository: InMemoryProductDefinitionRepository,
+  private val repository: CrudProductDefinitionRepository,
   dataRepository: ConfiguredApiRepository,
   identifiedHelper: IdentifiedHelper,
   establishmentCodesToWingsCacheService: EstablishmentCodesToWingsCacheService,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -81,6 +81,8 @@ dpr:
       role: ${AUTHORISED_ROLES}
     definition:
       locations: unused.json
+      redshift:
+        enabled: true
     redshiftdataapi:
       secretarn: ${REDSHIFT_DATA_SECRETARN}
       clusterid: ${REDSHIFT_DATA_CLUSTER_ID}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -41,3 +41,6 @@ dpr:
       rolesessionname: dpr-cross-account-role-session
       s3location: dpr-working-development/reports
       athenaworkgroup: athenaWorkgroup
+    definition:
+      redshift:
+        enabled: false


### PR DESCRIPTION
Added a configurable Redshift repository which can replace the in memory definitions repository.
The Redshift table is assumed to have an `ID` and a `DEFINITION` column. 
The ID is `VARCHAR` and the DEFINITION column is of type `SUPER`.