### PR TITLE
DPR2-2007 disable flyway

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,10 +118,10 @@ workflows:
           name: helm_lint
       - build_multiplatform_docker_job:
           name: build_docker
-#          filters:
-#            branches:
-#              only:
-#                - main
+          filters:
+            branches:
+              only:
+                - main
           requires:
             - helm_lint
             - validate
@@ -133,10 +133,10 @@ workflows:
           context:
             - hmpps-common-vars
             - hmpps-dpr-tools-api-dev
-#          filters:
-#            branches:
-#              only:
-#                - main
+          filters:
+            branches:
+              only:
+                - main
           requires:
             - validate
             - build_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,10 +118,10 @@ workflows:
           name: helm_lint
       - build_multiplatform_docker_job:
           name: build_docker
-          filters:
-            branches:
-              only:
-                - main
+#          filters:
+#            branches:
+#              only:
+#                - main
           requires:
             - helm_lint
             - validate
@@ -133,10 +133,10 @@ workflows:
           context:
             - hmpps-common-vars
             - hmpps-dpr-tools-api-dev
-          filters:
-            branches:
-              only:
-                - main
+#          filters:
+#            branches:
+#              only:
+#                - main
           requires:
             - validate
             - build_docker

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,8 @@ customdatasource:
     driver: com.amazon.redshift.jdbc.Driver
 
 spring:
+  flyway:
+    enabled: false
   application:
     name: hmpps-dpr-tools-api
   codec:


### PR DESCRIPTION
These changes disable flyway which is automatically enabled by default as the flyway dependency is on the classpath and there is at least one DataSource.
This needs to be disabled in tools-api as it does not make use of the missing report datasource and also uses Redshift which is not compatible with the default flyway configuration. 
Plus there is no Spring default datasource in this app so it tries to apply flyway on Redshift which fails.